### PR TITLE
Delete Insight

### DIFF
--- a/electrum/util.py
+++ b/electrum/util.py
@@ -646,10 +646,6 @@ def time_difference(distance_in_time, include_seconds):
         return "over %d years" % (round(distance_in_minutes / 525600))
 
 mainnet_block_explorers = {
-    'insight.bitzeny.jp': ('https://insight.bitzeny.jp/',
-                       {'tx': 'tx/', 'addr': 'address/'}),
-    'zeny.insight.monaco-ex.org': ('https://zeny.insight.monaco-ex.org/',
-                       {'tx': 'tx/', 'addr': 'address/'}),
     'zny.blockbook.ovh': ('https://zny.blockbook.ovh/',
                        {'tx': 'tx/', 'addr': 'address/'}),
 }


### PR DESCRIPTION
SegWit対応を完全にするべく、現時点で未対応のInsightを切り捨て、Blockbook一本化する案が出ました。
それに関して議論します。

私の案としては、現時点で運用されているBlockbookは1つだけ(正確には2つあるが1つが休止中)であり、ひとつに頼りきるのは少し問題があると考えます。複数に分散するのが仮想通貨、ブロックチェーンの強みであると考えるため、この案には否定的です。
InsightのSegWit対応も可能であるため、そこまで神経質にならなくてもいいと考えています。

・参考までに、Bech32に対応しているInsightのソースはこちらです。
https://github.com/ett126/bitcore-xpchain
https://github.com/ett126/insight-api-xpchain
https://github.com/ett126/insight-ui-xpchain